### PR TITLE
Feature: Use composer cache in Travis to speed up tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ env:
     - COMPOSER_FLAGS="--prefer-lowest"
     - COMPOSER_FLAGS=""
 
+cache:
+  directories:
+    - "$HOME/.composer/cache/"
+
 before_script:
     - travis_retry composer self-update
     - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-source

--- a/tests/AssertIn.php
+++ b/tests/AssertIn.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Tests;
 
 use NunoMaduro\LaravelMojito\InteractsWithViews;


### PR DESCRIPTION
Not much but this PR should save a couple of minutes when running Travis.