### PR TITLE
Enforce PSR2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
         "illuminate/view": "^6.0|^7.0",
         "phpstan/phpstan": "^0.12.11",
         "phpstan/phpstan-strict-rules": "^0.12",
-        "phpunit/phpunit": "^8.0|^9.0"
+        "phpunit/phpunit": "^8.0|^9.0",
+        "squizlabs/php_codesniffer": "^3.5"
     },
     "autoload-dev": {
         "psr-4": {
@@ -47,9 +48,11 @@
         "preferred-install": "dist"
     },
     "scripts": {
+        "test:styles": "phpcs",
         "test:types": "phpstan analyse --ansi",
         "test:unit": "phpunit --colors=always",
         "test": [
+            "@test:styles",
             "@test:types",
             "@test:unit"
         ]

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<ruleset name="PHP_CodeSniffer">
+    <file>./src</file>
+    <file>./tests</file>
+
+    <arg name="colors"/>
+    <arg value="sp"/>
+    <rule ref="PSR2"/>
+</ruleset>

--- a/tests/FakeView.php
+++ b/tests/FakeView.php
@@ -26,6 +26,8 @@ final class FakeView extends View
 
     public function render(callable $callback = null): string
     {
-        return (string) file_get_contents(__DIR__ . DIRECTORY_SEPARATOR . 'fixtures' . DIRECTORY_SEPARATOR . $this->name . '.html');
+        return (string) file_get_contents(
+            __DIR__ . DIRECTORY_SEPARATOR . 'fixtures' . DIRECTORY_SEPARATOR . $this->name . '.html'
+        );
     }
 }


### PR DESCRIPTION
Adding phpcs.xml.dist allows Travis to check all new commits follow PSR2.
Also, it allows editors and IDE to highlight errors based on the current configuration.