### PR TITLE
Adds a callable generator for Mail and Notification assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,41 @@ Filters the view and returns only the last element matching the selector.
 $this->assertView('welcome')->last('.links a')->contains('GitHub');
 ```
 
+### Assert Email Views
+
+You can also use the ViewAssertion class to generate a callable to use with Mail and Notification
+assertions making it easier to check that the contents of any emails your application delivers.
+
+For Mail assertions:
+
+```php
+Mail::fake();
+
+(new ExampleMailable)->send();
+
+Mail::assertSent(ExampleMailable::class, ViewAssertion::make(function (ViewAssertion $assertion) {
+    $assertion->contains('Hello World');
+
+    return true;
+}));
+```
+
+For Notification assertions:
+
+```php
+Notifications::fake();
+
+$user->notify(new Example());
+
+Notification::assertSentTo($user, ViewAssertion::make(
+    function (ViewAssertion $assertion, $channel, $notifiable, $locale) {
+        $assertion->contains('Hello World');
+    
+        return true;
+    }
+)); 
+```
+
 ### Macroable
 
 Fell free to add your own macros to the `ViewAssertion::class`.

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,8 @@
     "require-dev": {
         "illuminate/contracts": "^6.0|^7.0",
         "illuminate/support": "^6.0|^7.0",
+        "illuminate/mail": "^6.0|^7.0",
+        "illuminate/notifications": "^6.0|^7.0",
         "illuminate/view": "^6.0|^7.0",
         "phpstan/phpstan": "^0.12.11",
         "phpstan/phpstan-strict-rules": "^0.12",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -4,9 +4,12 @@ parameters:
         - src
         - tests
     ignoreErrors:
+        - '#Access to an undefined property Illuminate\\Contracts\\Mail\\Mailable::\$[a-zA-Z].#'
         - '#Call to an undefined method DOMNode::getAttribute\(\).#'
         - '#Call to an undefined method Tests\\IsMacroable::in\(\).#'
         - '#Call to an undefined method NunoMaduro\\LaravelMojito\\ViewAssertion::hasCharset\(\).#'
+        - '#Function resolve.*.#'
     checkMissingIterableValueType: false
     excludes_analyse:
         - "src/MojitoServiceProvider.php"
+        - "tests/FakeViewFactory.php"

--- a/tests/FakeViewFactory.php
+++ b/tests/FakeViewFactory.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\View\Factory;
+
+final class FakeViewFactory implements \Illuminate\Contracts\View\Factory
+{
+    public function flushFinderCache()
+    {
+    }
+
+    public function exists($view)
+    {
+    }
+
+    public function file($path, $data = [], $mergeData = [])
+    {
+    }
+
+    public function make($view, $data = [], $mergeData = [])
+    {
+        return new FakeView('welcome');
+    }
+
+    public function share($key, $value = null)
+    {
+    }
+
+    public function composer($views, $callback)
+    {
+    }
+
+    public function creator($views, $callback)
+    {
+    }
+
+    public function addNamespace($namespace, $hints)
+    {
+    }
+
+    public function replaceNamespace($namespace, $hints)
+    {
+        return $this;
+    }
+}

--- a/tests/Make.php
+++ b/tests/Make.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Mail\Mailable;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+use NunoMaduro\LaravelMojito\InteractsWithViews;
+use NunoMaduro\LaravelMojito\ViewAssertion;
+use PHPUnit\Framework\TestCase;
+
+final class Make extends TestCase
+{
+    use InteractsWithViews;
+
+    public function testItProcessesMailableAssertions() : void
+    {
+        $callable = ViewAssertion::make(function (ViewAssertion $assertion) {
+            $assertion->contains('Laravel');
+
+            return true;
+        });
+
+
+        $mailable = new class('email', []) extends Mailable {
+            public function __construct(string $view, array $viewData)
+            {
+                $this->view = $view;
+                $this->viewData = $viewData;
+            }
+        };
+
+        $callable($mailable);
+    }
+
+    public function testItProcessesNotificationProvidingMarkdownMailMessagesIntoViewAssertable() : void
+    {
+        $notification = new class extends Notification {
+            public function toMail() : MailMessage
+            {
+                return (new MailMessage());
+            }
+        };
+
+        $notifiable = new \stdClass();
+
+        $callable = ViewAssertion::make(function (
+            ViewAssertion $assertion,
+            $channel,
+            $notifiableInstance,
+            $locale
+        ) use ($notifiable) {
+            $assertion->contains('Laravel');
+            $this->assertSame($notifiable, $notifiableInstance);
+            $this->assertSame('mail', $channel);
+            $this->assertSame('en', $locale);
+
+            return true;
+        });
+
+        $callable($notification, 'mail', $notifiable, 'en');
+    }
+
+    public function testItProcessesNotificationProvidingViewMailMessagesIntoViewAssertable() : void
+    {
+        $notification = new class extends Notification {
+            public function toMail() : MailMessage
+            {
+                return (new MailMessage())->view('email');
+            }
+        };
+
+        $notifiable = new \stdClass();
+
+        $callable = ViewAssertion::make(function (
+            ViewAssertion $assertion,
+            $channel,
+            $notifiableInstance,
+            $locale
+        ) use ($notifiable) {
+            $assertion->contains('Laravel');
+            $this->assertSame($notifiable, $notifiableInstance);
+            $this->assertSame('mail', $channel);
+            $this->assertSame('en', $locale);
+
+            return true;
+        });
+
+        $callable($notification, 'mail', $notifiable, 'en');
+    }
+
+    public function testItProcessesNotificationMailableIntoViewAssertable() : void
+    {
+        $notification = new class extends Notification {
+            public function toMail() : Mailable
+            {
+                return new class('email', []) extends Mailable {
+                    public function __construct(string $view, array $viewData)
+                    {
+                        $this->view = $view;
+                        $this->viewData = $viewData;
+                    }
+                };
+            }
+        };
+
+        $notifiable = new \stdClass();
+
+        $callable = ViewAssertion::make(function (
+            ViewAssertion $assertion,
+            $channel,
+            $notifiableInstance,
+            $locale
+        ) use ($notifiable) {
+            $assertion->contains('Laravel');
+            $this->assertSame($notifiable, $notifiableInstance);
+            $this->assertSame('mail', $channel);
+            $this->assertSame('en', $locale);
+
+            return true;
+        });
+
+        $callable($notification, 'mail', $notifiable, 'en');
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,8 +1,26 @@
 <?php
 
+use Illuminate\Contracts\View\Factory;
+use Illuminate\Mail\Markdown;
 use Tests\FakeView;
+use Tests\FakeViewFactory;
 
 function view(string $name, array $_a, array $_b): FakeView
 {
     return new FakeView($name);
+}
+
+if (! function_exists('resolve')) {
+    function resolve(string $resolvable)
+    {
+        $view = new FakeViewFactory();
+
+        if ($resolvable === Markdown::class) {
+            return new Markdown($view);
+        } elseif ($resolvable === Factory::class) {
+            return $view;
+        }
+
+        throw new InvalidArgumentException('Resolvable is not configured for ' . $resolvable);
+    }
 }


### PR DESCRIPTION
Implements the feature described in issue #13. Adds a static make command that generates a callable that is compatible with both Mail and Notification assertions in Laravel that then calls a provided callable with a ViewAssertion as the first parameter making it possible to test the rendered email content.