### PR TITLE
Added hasMeta to view assertion

### DIFF
--- a/src/ViewAssertion.php
+++ b/src/ViewAssertion.php
@@ -148,6 +148,23 @@ final class ViewAssertion
     }
 
     /**
+     * Asserts that the view head has a meta tag with the given attributes array.
+     */
+    public function hasMeta(array $attributes): ViewAssertion {
+        $this->has('head');
+
+        $properties = implode('][', array_map(
+            function ($value, $key) {
+                return sprintf("%s='%s'", $key, $value);
+            },
+            $attributes,
+            array_keys($attributes)
+        ));
+
+        return $this->has("meta[{$properties}]");
+    }
+
+    /**
      * Returns the node of the current root element.
      *
      * @return DOMNode

--- a/src/ViewAssertion.php
+++ b/src/ViewAssertion.php
@@ -150,7 +150,8 @@ final class ViewAssertion
     /**
      * Asserts that the view head has a meta tag with the given attributes array.
      */
-    public function hasMeta(array $attributes): ViewAssertion {
+    public function hasMeta(array $attributes): ViewAssertion
+    {
         $this->has('head');
 
         $properties = implode('][', array_map(

--- a/tests/AssertHasMeta.php
+++ b/tests/AssertHasMeta.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * @internal
  */
-final class AssertHasMetaValues extends TestCase
+final class AssertHasMeta extends TestCase
 {
     use InteractsWithViews;
 

--- a/tests/AssertHasMeta.php
+++ b/tests/AssertHasMeta.php
@@ -1,0 +1,41 @@
+<?php
+
+
+namespace Tests;
+
+use NunoMaduro\LaravelMojito\InteractsWithViews;
+use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+final class AssertHasMetaValues extends TestCase
+{
+    use InteractsWithViews;
+
+    public function testHasMeta(): void
+    {
+        $this->assertView('welcome')->hasMeta([
+            'name'   =>  'viewport',
+            'content'   =>  'width=device-width, initial-scale=1'
+        ]);
+
+        $this->assertView('welcome')->hasMeta([
+            'charset'   =>  'utf-8'
+        ]);
+    }
+
+    public function testDoesNotHaveMeta(): void
+    {
+        $html = file_get_contents(__DIR__.'/fixtures/welcome.html');
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage(
+            "Failed asserting that `meta[property='og:title']` exists within `{$html}`"
+        );
+
+        $this->assertView('welcome')->hasMeta([
+            'property'   =>  'og:title'
+        ]);
+    }
+}


### PR DESCRIPTION
This change will let you check for meta tags within the head, without having to select using the number.

instead of:

`
$response->assertView()->in('head')->at('meta', 1)->hasAttribute('property', 'og:title');
`

you can do without specifying the number:

`
$response->assertView()->hasMeta(['property' => 'og:title']);
`

You can also check meta's with multiple attributes:


`
$response->assertView()->hasMeta([
    'property' => 'og:title',
    'content'  =>  'facebook title'
]);
`

It will simplify SEO meta testing.