### PR TITLE
Feat: add not modifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+- Added `not` modifier
+
 ## 0.2.8
 ### Added
 - Added `empty` assertion ([#22](https://github.com/nunomaduro/laravel-mojito/pull/22))

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -5,8 +5,9 @@ parameters:
         - tests
     ignoreErrors:
         - '#Call to an undefined method DOMNode::getAttribute\(\).#'
-        - '#Call to an undefined method Tests\\IsMacroable::in\(\).#'
+        - '#Call to an undefined method Tests\\AssertIsMacroable::in\(\).#'
         - '#Call to an undefined method NunoMaduro\\LaravelMojito\\ViewAssertion::hasCharset\(\).#'
+        - '#Call to an undefined method NunoMaduro\\LaravelMojito\\NotAssertion::#'
     checkMissingIterableValueType: false
     excludes_analyse:
         - "src/MojitoServiceProvider.php"

--- a/src/NotAssertion.php
+++ b/src/NotAssertion.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\LaravelMojito;
+
+use PHPUnit\Framework\ExpectationFailedException;
+
+final class NotAssertion
+{
+    /**
+     * @var ViewAssertion
+     */
+    protected $originalAssertion;
+
+    public function __construct(ViewAssertion $originalAssertion)
+    {
+        $this->originalAssertion = $originalAssertion;
+    }
+
+    public function not() : ViewAssertion
+    {
+        return $this->originalAssertion;
+    }
+
+    /**
+     * @throws \UnexpectedValueException
+     */
+    public function in(string $selector): ViewAssertion
+    {
+        throw new \UnexpectedValueException(
+            "Cannot use `in()` after `not()`. `not()` must be followed by an assertion."
+        );
+    }
+
+    /**
+     * @throws \UnexpectedValueException
+     */
+    public function at(string $selector, int $position): ViewAssertion
+    {
+        throw new \UnexpectedValueException(
+            "Cannot use `at()` after `not()`. `not()` must be followed by an assertion."
+        );
+    }
+
+    /**
+     * @throws \UnexpectedValueException
+     */
+    public function first(string $selector): ViewAssertion
+    {
+        throw new \UnexpectedValueException(
+            "Cannot use `first()` after `not()`. `not()` must be followed by an assertion."
+        );
+    }
+
+    /**
+     * @throws \UnexpectedValueException
+     *
+     * @return ViewAssertion
+     */
+    public function last(string $selector): ViewAssertion
+    {
+        throw new \UnexpectedValueException(
+            "Cannot use `last()` after `not()`. `not()` must be followed by an assertion."
+        );
+    }
+
+    /**
+     * Reverse the next assertion
+     * @param string $name
+     * @param mixed[] $arguments
+     * @return ViewAssertion
+     * @throws ExpectationFailedException
+     */
+    public function __call($name, $arguments)
+    {
+        try {
+            $this->originalAssertion->$name(...$arguments);
+        } catch (ExpectationFailedException $e) {
+            return $this->originalAssertion;
+        }
+
+
+        throw new ExpectationFailedException($this->getErrorMessage($name, $arguments));
+    }
+
+    /**
+     * Create an error message for the failed assertion, trying to make sense
+     * from the original name and arguments.
+     * @param string $name
+     * @param mixed[] $arguments
+     */
+    private function getErrorMessage($name, $arguments): string
+    {
+        $name = collect(preg_split('/(?=[A-Z])/', $name))
+            ->map(function ($word, $key) {
+                if (strtolower($word) === 'has') {
+                    return 'have';
+                }
+                return ($key === 0)
+                    ? preg_replace("/s\b/", "", strtolower($word))
+                    : strtolower($word);
+            })
+            ->implode(' ');
+
+
+        if (empty($arguments)) {
+            return 'Failed asserting that `'
+                . $this->originalAssertion->getHtml()
+                . '` is not '.$name;
+        }
+
+        if (count($arguments) === 2) {
+            return 'Failed asserting that `'
+                . $this->originalAssertion->getHtml()
+                . '` does not ' . $name
+                . ' `' . $arguments[0] . ' = ' . $arguments[1] . '`';
+        }
+
+        return 'Failed asserting that `'
+            . $this->originalAssertion->getHtml()
+            . '` does not ' . $name
+            . ' `' . implode(', ', array_map(
+                function ($item) {
+                    return is_array($item) ? json_encode($item) : $item;
+                },
+                (array) $arguments
+            )) . '`';
+    }
+}

--- a/src/ViewAssertion.php
+++ b/src/ViewAssertion.php
@@ -44,6 +44,22 @@ final class ViewAssertion
     }
 
     /**
+     * Get the html from the current view fragment
+     */
+    public function getHtml(): string
+    {
+        return $this->html;
+    }
+
+    /**
+     * Creates a new inverse assertion for the next selector.
+     */
+    public function not(): NotAssertion
+    {
+        return new NotAssertion($this);
+    }
+
+    /**
      * Creates a new view assertion with the given selector.
      */
     public function in(string $selector): ViewAssertion

--- a/tests/AssertContains.php
+++ b/tests/AssertContains.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace Tests;
 
 use NunoMaduro\LaravelMojito\InteractsWithViews;
@@ -20,7 +19,7 @@ final class AssertContains extends TestCase
         $this->assertView('welcome')->contains('<title>Laravel</title>');
     }
 
-    public function testDoesNotContain(): void
+    public function testContainsFailure(): void
     {
         $html = file_get_contents(__DIR__.'/fixtures/button.html');
         $this->expectException(AssertionFailedError::class);
@@ -45,5 +44,20 @@ final class AssertContains extends TestCase
             ->contains('AFTER')
             ->contains('WIDGETBEF')
             ->contains('WIDGETAFT');
+    }
+
+    public function testDoesNotContain(): void
+    {
+        $this->assertView('welcome')->not()->contains('<title>Mojito</title>');
+    }
+
+    public function testDoesNotFailure(): void
+    {
+        $html = file_get_contents(__DIR__.'/fixtures/button.html');
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage(
+            "Failed asserting that `{$html}` does not contain `Click me`"
+        );
+        $this->assertView('button')->not()->contains('Click me');
     }
 }

--- a/tests/AssertEmpty.php
+++ b/tests/AssertEmpty.php
@@ -21,10 +21,29 @@ final class AssertEmpty extends TestCase
         $this->assertView('empty')->in('.empty-with-space')->empty();
     }
 
-    public function testNotEmpty(): void
+    public function testEmptyFailure(): void
     {
         $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage(
+            "Failed asserting that the text `Hello` is empty"
+        );
 
-        $this->assertView('empty')->in('.not-empty')->empty();
+        $this->assertView('empty')->in('.not-empty-text')->empty();
+    }
+
+    public function testNotEmpty(): void
+    {
+        $this->assertView('button')->in('.btn')->not()->empty();
+    }
+
+    public function testNotEmptyFailure(): void
+    {
+        $html = '<div class="empty-div"></div>';
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage(
+            "Failed asserting that `{$html}` is not empty"
+        );
+
+        $this->assertView('empty')->in('.empty-div')->not()->empty();
     }
 }

--- a/tests/AssertHas.php
+++ b/tests/AssertHas.php
@@ -21,7 +21,7 @@ final class AssertHas extends TestCase
         $this->assertView('welcome')->in('body')->has('.content');
     }
 
-    public function testDoNotHas(): void
+    public function testHasFailure(): void
     {
         $html = file_get_contents(__DIR__.'/fixtures/alert.html');
         $this->expectException(AssertionFailedError::class);
@@ -30,5 +30,21 @@ final class AssertHas extends TestCase
         );
 
         $this->assertView('alert')->has('form');
+    }
+
+    public function testDoesNotHave(): void
+    {
+        $this->assertView('welcome')->not()->has('main');
+        $this->assertView('welcome')->in('body')->not()->has('.invalid');
+    }
+
+    public function testDoesNotHaveFailure(): void
+    {
+        $html = file_get_contents(__DIR__.'/fixtures/alert.html');
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage(
+            "Failed asserting that `{$html}` does not have `button`"
+        );
+        $this->assertView('alert')->not()->has('button');
     }
 }

--- a/tests/AssertHasAttribute.php
+++ b/tests/AssertHasAttribute.php
@@ -21,7 +21,7 @@ final class AssertHasAttribute extends TestCase
         $this->assertView('welcome')->in('head')->first('meta')->hasAttribute('charset', 'utf-8');
     }
 
-    public function testDoNotHasAttribute(): void
+    public function testHasAttributeFailure(): void
     {
         $html = file_get_contents(__DIR__.'/fixtures/button.html');
         $this->expectException(AssertionFailedError::class);
@@ -30,5 +30,23 @@ final class AssertHasAttribute extends TestCase
         );
 
         $this->assertView('button')->hasAttribute('prop', 'missing-value');
+    }
+
+    public function testDoesNotHaveAttribute(): void
+    {
+        $this->assertView('button')->not()->hasAttribute('prop', 'missing-value');
+        $this->assertView('welcome')->not()->hasAttribute('lang', 'it');
+        $this->assertView('welcome')->in('head')->first('meta')->not()->hasAttribute('charset', 'utf-16');
+    }
+
+    public function testDoesNotHaveAttributeFailure(): void
+    {
+        $html = file_get_contents(__DIR__.'/fixtures/button.html');
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage(
+            "Failed asserting that `{$html}` does not have attribute `prop = value`"
+        );
+
+        $this->assertView('button')->not()->hasAttribute('prop', 'value');
     }
 }

--- a/tests/AssertHasClass.php
+++ b/tests/AssertHasClass.php
@@ -20,7 +20,7 @@ final class AssertHasClass extends TestCase
         $this->assertView('welcome')->in('.content')->at('div > div', 0)->hasClass('title');
     }
 
-    public function testDoNotHasClass(): void
+    public function testHasClassFailure(): void
     {
         $html = file_get_contents(__DIR__.'/fixtures/button.html');
         $this->expectException(AssertionFailedError::class);
@@ -29,5 +29,21 @@ final class AssertHasClass extends TestCase
         );
 
         $this->assertView('button')->hasClass('btn-danger');
+    }
+
+    public function testDoesNotHaveClass(): void
+    {
+        $this->assertView('button')->not()->hasClass('btn-danger');
+    }
+
+    public function testDoesNotHaveClassFailure(): void
+    {
+        $html = file_get_contents(__DIR__.'/fixtures/button.html');
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage(
+            "Failed asserting that `{$html}` does not have class `btn`"
+        );
+
+        $this->assertView('button')->not()->hasClass('btn');
     }
 }

--- a/tests/AssertHasLink.php
+++ b/tests/AssertHasLink.php
@@ -22,7 +22,7 @@ final class AssertHasLink extends TestCase
         $this->assertView('welcome')->in('.links')->last('a')->hasLink('https://github.com/laravel/laravel');
     }
 
-    public function testDoNotLink(): void
+    public function testHasLinkFailure(): void
     {
         $html = file_get_contents(__DIR__.'/fixtures/button.html');
         $this->expectException(AssertionFailedError::class);
@@ -31,5 +31,21 @@ final class AssertHasLink extends TestCase
         );
 
         $this->assertView('button')->hasLink('https://link-that-is-not-there.com');
+    }
+
+    public function testDoesNotHaveLink(): void
+    {
+        $this->assertView('button')->not()->hasLink('https://link-that-is-not-there.com');
+    }
+
+    public function testDoesNotHaveLinkFailure(): void
+    {
+        $html = file_get_contents(__DIR__.'/fixtures/button.html');
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage(
+            "Failed asserting that `{$html}` does not have link `https://link.com`"
+        );
+
+        $this->assertView('button')->not()->hasLink('https://link.com');
     }
 }

--- a/tests/AssertHasMeta.php
+++ b/tests/AssertHasMeta.php
@@ -22,11 +22,11 @@ final class AssertHasMeta extends TestCase
         ]);
 
         $this->assertView('welcome')->hasMeta([
-            'charset'   =>  'utf-8'
+            'charset' => 'utf-8'
         ]);
     }
 
-    public function testDoesNotHaveMeta(): void
+    public function testHasMetaFailure(): void
     {
         $html = file_get_contents(__DIR__.'/fixtures/welcome.html');
         $this->expectException(AssertionFailedError::class);
@@ -36,6 +36,27 @@ final class AssertHasMeta extends TestCase
 
         $this->assertView('welcome')->hasMeta([
             'property'   =>  'og:title'
+        ]);
+    }
+
+    public function testDoesNotHaveMeta(): void
+    {
+        $this->assertView('welcome')->not()->hasMeta([
+            'property' => 'og:title'
+        ]);
+    }
+
+
+    public function testDoesNotHaveMetaFailure(): void
+    {
+        $html = file_get_contents(__DIR__.'/fixtures/welcome.html');
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage(
+            "Failed asserting that `{$html}` does not have meta `{\"charset\":\"utf-8\"}`"
+        );
+
+        $this->assertView('welcome')->not()->hasMeta([
+            'charset' => 'utf-8'
         ]);
     }
 }

--- a/tests/AssertIsMacroable.php
+++ b/tests/AssertIsMacroable.php
@@ -7,7 +7,10 @@ use NunoMaduro\LaravelMojito\ViewAssertion;
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\TestCase;
 
-final class IsMacroable extends TestCase
+/**
+ * @internal
+ */
+final class AssertIsMacroable extends TestCase
 {
     use InteractsWithViews;
 
@@ -25,7 +28,7 @@ final class IsMacroable extends TestCase
         $this->assertView('welcome')->hasCharset('utf-8');
     }
 
-    public function testDoNotHasCharset(): void
+    public function testHasCharsetFailure(): void
     {
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage(
@@ -33,5 +36,22 @@ final class IsMacroable extends TestCase
         );
 
         $this->assertView('welcome')->hasCharset('not-valid');
+    }
+
+    public function testDoesNotHaveCharset(): void
+    {
+        $this->assertView('welcome')->not()->hasCharset('utf-16');
+    }
+
+    public function testDoesNotHaveCharsetFailure(): void
+    {
+        $html = file_get_contents(__DIR__.'/fixtures/welcome.html');
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage(
+            "Failed asserting that `{$html}` does not have charset `utf-8`"
+        );
+
+        $this->assertView('welcome')->not()->hasCharset('utf-8');
     }
 }


### PR DESCRIPTION
This PR adds a chain-able `not` modifier to test an inverted assertion.
The syntax is `$this->assertView('welcome')->not()->contains('<title>Mojito</title>');`

Quick notes:
- the error messages are generated automatically trying to apply a bunch of conventions so the generated text does not sound too weird. 
- it supports custom macros, if developers follow the same naming strategy the error message should be intelligible but we can't guarantee that. 
- calling `->not()` twice returns the original assertion. I.e. `$this->assertView('welcome')->not()->not()->contains('<title>Laravel</title>');` passes the test.
- at the moment, is not possible to call `->not()` before `in`, `at`, `first` and `last` since they don't really assert anything and I wasn't sure about what behaviour would be desired here. At the minute, it would trigger an exception but we can improve it in one of the next iterations if needed.
- I renamed an existing test class because PHPUnit wasn't picking it up.